### PR TITLE
Renamed timers.Get to timers.From

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -19,12 +19,12 @@ it yourself, but that's not the idea.
 ## Chaining and defer
 Timers can be chained, which provides a very nice interaction.
 ```
-t := timers.Get(ctx).New("My New Timer").Tag("mine").Start()
+t := timers.Set(ctx).New("My New Timer").Tag("mine").Start()
 ```
 Due to the chaining they can be used to measure an entire function with just one line:
 ```
 func MyFunction(ctx context.Context, args...) {
-    defer timers.Get(ctx).New("MyFunction").Start().Stop()
+    defer timers.Set(ctx).New("MyFunction").Start().Stop()
     ...
 }
 ```
@@ -35,8 +35,8 @@ Timers can be grouped by deriving a new context.
 ```
 func MyFunc(ctx context.Context) {
     newCtx, _ := timers.NewContextWithTimer(ctx, "A new group of timers that are under the previous ctx")  
-    timers.Get(newCtx).New("Timer1")
-    timers.Get(newCtx).New("Timer2")
+    timers.Set(newCtx).New("Timer1")
+    timers.Set(newCtx).New("Timer2")
 }
 ```
 
@@ -46,11 +46,11 @@ func MyFunc(ctx context.Context) {
     ...
     // You have to provide the ctx to the Wrap function as the TimerSet itself
     // does not hold the context to avoid leaking it. 
-    timers.Get(ctx).Wrap(ctx, "A library call", func(ctx context.Context) {
+    timers.Set(ctx).Wrap(ctx, "A library call", func(ctx context.Context) {
         MakeSomeCall(ctx, ...)
     })
     // All timers that MakeSomeCall() created are under "A library call" timer. 
-    for _, t := range timers.Get(ctx).Get("A library call").Children {
+    for _, t := range timers.Set(ctx).Find("A library call").Children {
       fmt.Println(t) // Prints all the timers that were created.
     }
 }

--- a/examples/main.go
+++ b/examples/main.go
@@ -21,7 +21,7 @@ func otherMajorWork(ctx context.Context, wg *sync.WaitGroup) {
 func moreMajorWork(ctx context.Context) {
 	fmt.Println("more major work starting")
 	time.Sleep(time.Duration(rand.Intn(1000) * int(time.Millisecond)))
-	timers.Get(ctx).Wrap(ctx, "subwork", func(ctx context.Context) {
+	timers.From(ctx).Wrap(ctx, "subwork", func(ctx context.Context) {
 		fmt.Println("Subwork going on")
 		time.Sleep(time.Duration(rand.Intn(500)) * time.Millisecond)
 		fmt.Println("subwork finished")
@@ -32,10 +32,10 @@ func main() {
 	ctx := timers.NewContext(context.Background())
 	// do things
 	func() {
-		defer timers.Get(ctx).New("Measure Sleep").Start().Stop()
+		defer timers.From(ctx).New("Measure Sleep").Start().Stop()
 		time.Sleep(100 * time.Millisecond)
 	}()
-	t := timers.Get(ctx).New("Count to a hundred million")
+	t := timers.From(ctx).New("Count to a hundred million")
 	t.Start()
 	for i := 0; i < 100000000; i++ {
 	}
@@ -49,7 +49,7 @@ func main() {
 		wg := sync.WaitGroup{}
 		for i := 0; i < 2; i++ {
 			wg.Add(1)
-			go timers.Get(ctx).Wrap(ctx, "majorWork", func(ctx context.Context) {
+			go timers.From(ctx).Wrap(ctx, "majorWork", func(ctx context.Context) {
 				otherMajorWork(ctx, &wg)
 			})
 		}
@@ -63,11 +63,11 @@ func main() {
 	t.Stop()
 
 	fmt.Println("\nLets see how we did:")
-	for _, t := range timers.Get(ctx).AllDeep() {
+	for _, t := range timers.From(ctx).AllDeep() {
 		fmt.Println(t)
 	}
 	fmt.Println("\n\nAs a tree")
-	timers.Get(ctx).Tree(func(timer timers.Timer, depth int, _ *timers.TimerSet) {
+	timers.From(ctx).Tree(func(timer timers.Timer, depth int, _ *timers.TimerSet) {
 		fmt.Printf("%s %s\n", strings.Repeat(" ", depth), timer.String())
 	})
 }

--- a/examples/waterfall/waterfall.go
+++ b/examples/waterfall/waterfall.go
@@ -18,7 +18,7 @@ var fakeTimings *timers.TimerSet
 
 func main() {
 	// Grab a new TimerSet
-	fakeTimings = timers.Get(context.Background())
+	fakeTimings = timers.From(context.Background())
 	err := json.Unmarshal(jsonData, fakeTimings)
 	if err != nil {
 		fmt.Printf("Failed to unmarshal timers json: %s\n", err.Error())

--- a/examples/webserver/webserver.go
+++ b/examples/webserver/webserver.go
@@ -23,11 +23,11 @@ func doWork() {
 }
 
 func apiFunc1(ctx context.Context) {
-	defer timers.Get(ctx).New("apiFunc1").Start().Stop()
+	defer timers.From(ctx).New("apiFunc1").Start().Stop()
 	// Doing work
 	doWork()
 
-	t := timers.Get(ctx).New("Downstream1").Start()
+	t := timers.From(ctx).New("Downstream1").Start()
 	doWork() // Make a call downstream
 	t.Stop()
 	apiFunc1a(ctx)
@@ -35,25 +35,25 @@ func apiFunc1(ctx context.Context) {
 
 }
 func apiFunc1a(ctx context.Context) {
-	defer timers.Get(ctx).New("apiFunc1a").Start().Stop()
+	defer timers.From(ctx).New("apiFunc1a").Start().Stop()
 	// Doing work
 	doWork()
 
-	t := timers.Get(ctx).New("Downstream2").Start()
+	t := timers.From(ctx).New("Downstream2").Start()
 	doWork() // Make a call downstream
 	t.Stop()
 }
 func apiFunc1b(ctx context.Context) {
-	defer timers.Get(ctx).New("apiFunc1b").Start().Stop()
+	defer timers.From(ctx).New("apiFunc1b").Start().Stop()
 	// Doing work
 	doWork()
 
-	t := timers.Get(ctx).New("Downstream3").Start()
+	t := timers.From(ctx).New("Downstream3").Start()
 	doWork() // Make a call downstream
 	t.Stop()
 }
 func apiFunc2(ctx context.Context) {
-	defer timers.Get(ctx).New("apiFunc2").Start().Stop()
+	defer timers.From(ctx).New("apiFunc2").Start().Stop()
 	doWork()
 	apiFunc3(ctx)
 	// Lots of work
@@ -63,23 +63,23 @@ func apiFunc2(ctx context.Context) {
 	apiFunc4(ctx)
 }
 func apiFunc3(ctx context.Context) {
-	defer timers.Get(ctx).New("apiFunc3").Start().Stop()
+	defer timers.From(ctx).New("apiFunc3").Start().Stop()
 	doWork()
 }
 func apiFunc4(ctx context.Context) {
-	defer timers.Get(ctx).New("apiFunc4").Start().Stop()
+	defer timers.From(ctx).New("apiFunc4").Start().Stop()
 	doWork()
 }
 
 func apiSampleEndpoint(w http.ResponseWriter, r *http.Request) {
 
 	doWork()
-	timers.Get(r.Context()).Wrap(r.Context(), "calling apiFunc to do work", func(ctx context.Context) {
+	timers.From(r.Context()).Wrap(r.Context(), "calling apiFunc to do work", func(ctx context.Context) {
 		apiFunc1(ctx)
 	})
 	apiFunc2(r.Context())
 	// Output headers
-	timers.Get(r.Context()).AddHeader(w)
+	timers.From(r.Context()).AddHeader(w)
 	w.WriteHeader(200)
 	// Output body
 	fmt.Fprintf(w, "Request ended")
@@ -92,7 +92,7 @@ func timerMiddleware(next http.Handler) http.Handler {
 		ctx = timers.NewContext(ctx)
 		name := r.URL.Path
 
-		timers.Get(ctx).New(name).Start()
+		timers.From(ctx).New(name).Start()
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/examples_test.go
+++ b/examples_test.go
@@ -22,7 +22,7 @@ func majorWork(ctx context.Context, wg *sync.WaitGroup) {
 func moreMajorWork(ctx context.Context) {
 	fmt.Println("more major work starting")
 	time.Sleep(time.Duration(rand.Intn(1000) * int(time.Millisecond)))
-	timers.Get(ctx).Wrap(ctx, "subwork", func(ctx context.Context) {
+	timers.From(ctx).Wrap(ctx, "subwork", func(ctx context.Context) {
 		fmt.Println("Subwork going on")
 		time.Sleep(time.Duration(rand.Intn(500)) * time.Millisecond)
 		fmt.Println("subwork finished")
@@ -36,10 +36,10 @@ func Example() {
 
 	// do things
 	func() {
-		defer timers.Get(ctx).New("Measure Sleep").Start().Stop()
+		defer timers.From(ctx).New("Measure Sleep").Start().Stop()
 		time.Sleep(100 * time.Millisecond)
 	}()
-	t := timers.Get(ctx).New("Count to a hundred million")
+	t := timers.From(ctx).New("Count to a hundred million")
 	t.Start()
 	for i := 0; i < 100000000; i++ {
 	}
@@ -56,7 +56,7 @@ func Example() {
 		wg := sync.WaitGroup{}
 		for i := 0; i < 2; i++ {
 			wg.Add(1)
-			go timers.Get(ctx).Wrap(ctx, "majorWork", func(ctx context.Context) {
+			go timers.From(ctx).Wrap(ctx, "majorWork", func(ctx context.Context) {
 				majorWork(ctx, &wg)
 			})
 		}
@@ -70,11 +70,11 @@ func Example() {
 	t.Stop()
 
 	fmt.Println("\nLets see how we did:")
-	for _, t := range timers.Get(ctx).AllDeep() {
+	for _, t := range timers.From(ctx).AllDeep() {
 		fmt.Println(t)
 	}
 	fmt.Println("\n\nAs a tree")
-	timers.Get(ctx).Tree(func(timer timers.Timer, depth int, _ *timers.TimerSet) {
+	timers.From(ctx).Tree(func(timer timers.Timer, depth int, _ *timers.TimerSet) {
 		fmt.Printf("%s %s\n", strings.Repeat(" ", depth), timer.String())
 	})
 
@@ -89,14 +89,14 @@ func ExampleTimerSet_New() {
 	ctx := context.Background()
 	// At the top of the function we put this one line, and the "My Function" timer in
 	// the current ctx now has the duration of this function.
-	defer timers.Get(ctx).New("My function").Start().Stop()
+	defer timers.From(ctx).New("My function").Start().Stop()
 
 	// The New function supports string formatting directives using fmt.Sprintf
-	defer timers.Get(ctx).New("My function(%s, %d)", "Calling Parameter", 5)
+	defer timers.From(ctx).New("My function(%s, %d)", "Calling Parameter", 5)
 }
 func ExampleTimer_Tags() {
 	// Grab a floating timer from the background context, which has no timerset
-	timer := timers.Get(context.Background()).New("MyFunc")
+	timer := timers.From(context.Background()).New("MyFunc")
 	// Assign it a tag and start
 	timer.Tag("Test").Start()
 	fmt.Printf("%s", timer.Tags())
@@ -116,27 +116,27 @@ func ExampleNewContextWithTimer() {
 	t.Start()
 	goDoSomeWork(newCtx)
 	t.Stop()
-	workTimerSet := timers.Get(newCtx)
+	workTimerSet := timers.From(newCtx)
 	fmt.Printf("Work took %d ms and produced %d timers", t.Duration(), len(workTimerSet.All()))
 }
 
 func ExampleTimerSet_Wrap() {
 	ctx := timers.NewContext(context.Background())
-	timers.Get(ctx).New("Stuff").Start().Stop()
-	timers.Get(ctx).Wrap(ctx, "Some Work", func(ctx context.Context) {
-		timers.Get(ctx).New("work step 1").Start().Stop()
-		timers.Get(ctx).New("work step 2").Start().Stop()
-		timers.Get(ctx).New("work step 3").Start().Stop()
+	timers.From(ctx).New("Stuff").Start().Stop()
+	timers.From(ctx).Wrap(ctx, "Some Work", func(ctx context.Context) {
+		timers.From(ctx).New("work step 1").Start().Stop()
+		timers.From(ctx).New("work step 2").Start().Stop()
+		timers.From(ctx).New("work step 3").Start().Stop()
 	})
 
 }
 
 func ExampleTimerSet_MarshalJSON() {
 	ctx := timers.NewContext(context.Background())
-	timers.Get(ctx).New("Timer 1")
-	timers.Get(ctx).New("Timer 1")
-	timers.Get(ctx).New("Timer 1")
-	bytes, _ := json.MarshalIndent(timers.Get(ctx), "", " ")
+	timers.From(ctx).New("Timer 1")
+	timers.From(ctx).New("Timer 1")
+	timers.From(ctx).New("Timer 1")
+	bytes, _ := json.MarshalIndent(timers.From(ctx), "", " ")
 	fmt.Print(string(bytes))
 	// Output:
 	//[


### PR DESCRIPTION
Before hitting release version, decided that timers.Get isn't quite
clear that you are getting a TimerSet, so renamed function to
timers.From.

Theory goes when reading the code it reads:

  timers.From(ctx).New("blah")...

which one would read timers from context new