### PR TITLE
Added middleware functionality

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -47,16 +47,29 @@ the Server-Timings header and waterfall display.
 
 ### http headers
 <img align="right" src="waterfall.png" alt="waterfall example" width="300"/>
-Coming real soon is a full middleware, but available now is TimerSet.AddHeader(http.ResponseWriter) which
-adds the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server-Timing">Server-Timing header</a>.
+The Middleware function registers a http handler that adds a TimerSet to the request context, and writes
+the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server-Timing">Server-Timing header</a>. 
 
 Once a Server-Timing header is set, you can view the timings either using the in browser inspector, or you
 can use the go-timers built-in waterfall display.
 
+```
+mux := http.NewServeMux()
+mux.HandleFunc("/api", func(w http.ResponseWriter, r *http.Request) {
+    defer timers.From(r.Context()).New("Api Function").Start().Stop()
+    // Do stuff.
+    fmt.Fprintf(w, "Results of stuff")
+})
+// Add the waterfall handler too.
+// Note the trailing slashes are important!
+mux.Handle("/waterfall/", http.StripPrefix("/waterfall/", timers.WaterfallHandler()))
+handler := timers.Middleware(mux, timers.MiddlewareOptions{})
+http.ListenAndServe("127.0.0.1:3000", handler)
+```
+
 ### Waterfall
 By calling `timers.WaterfallHandler()` you get a http Handler that will render a waterfall of calls to your
 web process. See the `examples/waterfall` directory for a very simple example. 
-
 
 ## Grouping/children
 Timers can be grouped by deriving a new context.

--- a/examples/webserver/webserver.go
+++ b/examples/webserver/webserver.go
@@ -15,7 +15,8 @@ func main() {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api", apiSampleEndpoint)
 	mux.Handle("/waterfall/", http.StripPrefix("/waterfall/", timers.WaterfallHandler()))
-	log.Fatal(http.ListenAndServe("127.0.0.1:3000", timerMiddleware(mux)))
+	handler := timers.Middleware(mux, timers.MiddlewareOptions{})
+	log.Fatal(http.ListenAndServe("127.0.0.1:3000", handler))
 }
 
 func doWork() {
@@ -84,15 +85,4 @@ func apiSampleEndpoint(w http.ResponseWriter, r *http.Request) {
 	// Output body
 	fmt.Fprintf(w, "Request ended")
 
-}
-
-func timerMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
-		ctx = timers.NewContext(ctx)
-		name := r.URL.Path
-
-		timers.From(ctx).New(name).Start()
-		next.ServeHTTP(w, r.WithContext(ctx))
-	})
 }

--- a/examples_test.go
+++ b/examples_test.go
@@ -118,8 +118,7 @@ func ExampleTimer_Measure() {
 	})
 	ms := timers.From(ctx).Find("apiCall").Milliseconds()
 	fmt.Println(math.Floor(ms))
-	// Output:
-	// 10
+	// Would print "10", except if time.Sleep() takes longer
 }
 
 func goDoSomeWork(_ context.Context) {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/zafnz/go-timers
 
 go 1.17
+
+require github.com/felixge/httpsnoop v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
+github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=

--- a/middleware.go
+++ b/middleware.go
@@ -7,13 +7,25 @@ import (
 )
 
 type MiddlewareOptions struct {
-	Callback func(*TimerSet) // This function will be called at the end of the request
+	Callback       func(*TimerSet) // This function will be called at the end of the request
+	NoDefaultTimer bool            // If true, then no default timer will be set.
 }
 
+// The middleware function sets up timers for each request, and for each request emits
+// a Server-Timing header. A default "Request" timer is created, unless the option
+// NoDefaultTimer is true. Use this function as you would any other middleware function
+//  handler = timers.Middleware(handler, MiddlewareOptions{})
 func Middleware(next http.Handler, opts MiddlewareOptions) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := NewContext(r.Context())
 		r = r.WithContext(ctx)
+		var t *Timer
+
+		if opts.NoDefaultTimer {
+			t = &Timer{}
+		} else {
+			t = From(ctx).New("Request").Start()
+		}
 
 		// TimerSet.AddHeader() always adds a Server-Timing header, because users might want
 		// to write out multiple timings, one for each set. So we need to make sure we don't
@@ -25,6 +37,7 @@ func Middleware(next http.Handler, opts MiddlewareOptions) http.Handler {
 			WriteHeader: func(original httpsnoop.WriteHeaderFunc) httpsnoop.WriteHeaderFunc {
 				return func(code int) {
 					headerAdded = true
+					t.Stop()
 					From(ctx).AddHeader(w)
 					original(code)
 				}
@@ -32,6 +45,7 @@ func Middleware(next http.Handler, opts MiddlewareOptions) http.Handler {
 			Write: func(original httpsnoop.WriteFunc) httpsnoop.WriteFunc {
 				return func(b []byte) (int, error) {
 					headerAdded = true
+					t.Stop()
 					From(ctx).AddHeader(w)
 					return original(b)
 				}
@@ -40,6 +54,7 @@ func Middleware(next http.Handler, opts MiddlewareOptions) http.Handler {
 		w = httpsnoop.Wrap(w, h)
 		next.ServeHTTP(w, r)
 		if !headerAdded {
+			t.Stop()
 			From(ctx).AddHeader(w)
 		}
 		if opts.Callback != nil {

--- a/middleware.go
+++ b/middleware.go
@@ -1,0 +1,49 @@
+package timers
+
+import (
+	"net/http"
+
+	"github.com/felixge/httpsnoop"
+)
+
+type MiddlewareOptions struct {
+	Callback func(*TimerSet) // This function will be called at the end of the request
+}
+
+func Middleware(next http.Handler, opts MiddlewareOptions) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := NewContext(r.Context())
+		r = r.WithContext(ctx)
+
+		// TimerSet.AddHeader() always adds a Server-Timing header, because users might want
+		// to write out multiple timings, one for each set. So we need to make sure we don't
+		// duplicate things ourselves.
+		headerAdded := false
+
+		// Hook into both WriteHeader and Write, to add our header just before it's too late.
+		h := httpsnoop.Hooks{
+			WriteHeader: func(original httpsnoop.WriteHeaderFunc) httpsnoop.WriteHeaderFunc {
+				return func(code int) {
+					headerAdded = true
+					From(ctx).AddHeader(w)
+					original(code)
+				}
+			},
+			Write: func(original httpsnoop.WriteFunc) httpsnoop.WriteFunc {
+				return func(b []byte) (int, error) {
+					headerAdded = true
+					From(ctx).AddHeader(w)
+					return original(b)
+				}
+			},
+		}
+		w = httpsnoop.Wrap(w, h)
+		next.ServeHTTP(w, r)
+		if !headerAdded {
+			From(ctx).AddHeader(w)
+		}
+		if opts.Callback != nil {
+			opts.Callback(From(ctx))
+		}
+	})
+}

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -1,0 +1,88 @@
+package timers_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/zafnz/go-timers"
+)
+
+func TestMiddleware(t *testing.T) {
+	rr := httptest.NewRecorder()
+
+	req, err := http.NewRequest("POST", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		timers.From(r.Context()).New("test").Start().Stop()
+	})
+
+	middleware := timers.Middleware(handler, timers.MiddlewareOptions{})
+	middleware.ServeHTTP(rr, req)
+	if rr.Code != 200 {
+		t.Fatal("Something broke")
+	}
+	timingHeader := rr.Header().Get("Server-Timing")
+	if timingHeader == "" {
+		t.Fatal("No server timing header")
+	}
+	if !strings.Contains(timingHeader, "descr=\"test\"") {
+		t.Error("Server-Timing does not contain test timer")
+	}
+}
+
+func TestMiddlewareWrite(t *testing.T) {
+	rr := httptest.NewRecorder()
+
+	req, err := http.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		timers.From(r.Context()).New("test").Start().Stop()
+		fmt.Fprintln(w, "output")
+	})
+
+	middleware := timers.Middleware(handler, timers.MiddlewareOptions{})
+	middleware.ServeHTTP(rr, req)
+	if rr.Code != 200 {
+		t.Fatal("Something broke")
+	}
+	timingHeader := rr.Header().Get("Server-Timing")
+	if timingHeader == "" {
+		t.Fatal("No server timing header")
+	}
+	if !strings.Contains(timingHeader, "descr=\"test\"") {
+		t.Error("Server-Timing does not contain test timer")
+	}
+}
+
+func TestMiddlewareWriteHeader(t *testing.T) {
+	rr := httptest.NewRecorder()
+
+	req, err := http.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		timers.From(r.Context()).New("test").Start().Stop()
+		w.WriteHeader(300)
+	})
+
+	middleware := timers.Middleware(handler, timers.MiddlewareOptions{})
+	middleware.ServeHTTP(rr, req)
+	if rr.Code != 300 {
+		t.Fatal("Something broke")
+	}
+	timingHeader := rr.Header().Get("Server-Timing")
+	if timingHeader == "" {
+		t.Fatal("No server timing header")
+	}
+	if !strings.Contains(timingHeader, "descr=\"test\"") {
+		t.Error("Server-Timing does not contain test timer")
+	}
+}

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -10,6 +10,18 @@ import (
 	"github.com/zafnz/go-timers"
 )
 
+func ExampleMiddleware() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api", func(w http.ResponseWriter, r *http.Request) {
+		defer timers.From(r.Context()).New("Api Function").Start().Stop()
+	})
+	// Add the waterfall handler too.
+	// Note the trailing slashes are important!
+	mux.Handle("/waterfall/", http.StripPrefix("/waterfall/", timers.WaterfallHandler()))
+	handler := timers.Middleware(mux, timers.MiddlewareOptions{})
+	http.ListenAndServe("127.0.0.1:3000", handler)
+}
+
 func TestMiddleware(t *testing.T) {
 	rr := httptest.NewRecorder()
 


### PR DESCRIPTION
Added full middleware support with the aid of httpsnoop. The middleware adds a `TimerSet` to the `request.Context()`, and adds the `Server-Timing` http header to the response. 

Closes #11 
